### PR TITLE
Update dnn-compatibility.md

### DIFF
--- a/docs/modules/important-notes/dnn-compatibility.md
+++ b/docs/modules/important-notes/dnn-compatibility.md
@@ -21,9 +21,8 @@ To see the Evoq Content versions that correspond to the DNN Platform versions li
 
 | DNN Version | Min Plant an App Version | Min DNNSharp Module Version | Notes |
 |-|-|-|-|
-| Above 9.8.1 | - | - | Currently in QA |
-| Above 9.8.0 | - | - | Not yet supported |
-| 9.8.0 | 1.9.x | 5.9.x |  |
+| Above 9.8.1 | - | - | Not yet supported |
+| 9.8.1 | 1.9.x | 5.9.x |  |
 | **9.7.2** | **1.9.x** | **5.9.x** | **Starting with DNN 9.7.2, DNN Sharp version 5.9.x or above or Plant an App 1.9.x or above is Required** |
 | 9.6.2 | 1.6.x | 5.6.x | DNN Version 9.6.2 is not recommended. This is the max DNN version compatible with DNN Sharp 5.8.x  and lower or Plant an App 1.8.x and lower  |
 | **9.6.1** | **1.6.x** | **5.6.x** |  |


### PR DESCRIPTION
Changes to reflect announcement in LCC #35 that 9.8.1. is certified and 9.9.0 is targeted for 1.13 release.