### PR TITLE
Update dnn-compatibility.md

### DIFF
--- a/docs/modules/important-notes/dnn-compatibility.md
+++ b/docs/modules/important-notes/dnn-compatibility.md
@@ -24,7 +24,7 @@ To see the Evoq Content versions that correspond to the DNN Platform versions li
 | DNN Version | Min Plant an App Version | Min DNNSharp Module Version | Notes |
 |-|-|-|-|
 | Above 9.9.0 | - | - | Not yet supported |
-| 9.9.0 | 1.9.x | 5.9.x | - |
+| 9.9.0 | 1.13.x | 5.13.x | **Starting with DNN 9.9.0, DNN Sharp version 5.13.x or above or Plant an App 1.13.x or above is Required** |
 | 9.8.1 | 1.9.x | 5.9.x | DNN 9.8.1 is the recommended version. |
 | **9.7.2** | **1.9.x** | **5.9.x** | **Starting with DNN 9.7.2, DNN Sharp version 5.9.x or above or Plant an App 1.9.x or above is Required** |
 | 9.6.2 | 1.6.x | 5.6.x | DNN Version 9.6.2 is not recommended. This is the max DNN version compatible with DNN Sharp 5.8.x  and lower or Plant an App 1.8.x and lower  |


### PR DESCRIPTION
Changes to communicate that dnn 9.9.0 will fail in some cases (emailsync) if not up to 5.13/1.13